### PR TITLE
Fix vanilla shooters

### DIFF
--- a/asm/giepy/shooter.asm
+++ b/asm/giepy/shooter.asm
@@ -27,7 +27,7 @@ pullpc
 ;   be not execute.
 ;-------------------------------------------------
 SetShooterExBits:
-	sbc.b	#$cb
+	sbc.b	#$c8
 	sta.w	!1783,x
 if !EXTRA_BYTES_EXT
 	lda.b	#0


### PR DESCRIPTION
# Summary
This pull request fixes issue #10. The `SetShooterExBits` routine does not correctly restore the original code, which leads to a crash when using vanilla shooters.

All custom sprites skip over the vanilla code, so this shouldn't break anything.