### PR TITLE
Fix vanilla generators

### DIFF
--- a/asm/giepy/generator.asm
+++ b/asm/giepy/generator.asm
@@ -40,6 +40,7 @@ GeneratorHijack:
 
 +	lda.l	!extra_bits_gen
 	bmi	.isCustom
+	lda.w	!18b9
 	jml	$02b007|!bankB			; origin generator
 
 .isCustom


### PR DESCRIPTION
# Summary
The `GeneratorHijack` routine modifies A to get the extra bits but doesn't restore it before calling a vanilla generator. $02B007, the return location, expects the generator number to be loaded in A.

Because of the `DEC A` at $02B007, all vanilla generators are treated as generator FF. Surprisingly, this doesn't crash the game, but it does nothing useful.