### PR TITLE
Overhaul sprite loading

### DIFF
--- a/asm/giepy/normspr.asm
+++ b/asm/giepy/normspr.asm
@@ -11,7 +11,7 @@ pushpc
 	else
 		%org_assert_long2($02a9d4, c81f,e29d)
 	endif
-		jsl	LoadNrmSprExtraInfo
+		jml	LoadNrmSprExtraInfo
 
 	if !true == !sa1
 		%org_assert_long2($018172, 429d,08a9)
@@ -124,8 +124,14 @@ LoadNrmSprExtraInfo:
 	%putdebug("LoadNrmSprExtraInfo")
 	sta.w	!1fe2,x
 
+if !true == !sa1
+	pla
+	pla
+endif
+
 if !true == !EXTRA_BYTES_EXT
 	;--- get extra bytes length
+	phy
 	jsr	LoadExBytesSub
 	beq	.return			;\  Load extra bytes.
 -	lda.b	[$ce],y			; | if extra bytes size greater than 7,
@@ -148,11 +154,13 @@ if !true == !EXTRA_BYTES_EXT
 	iny				; |
 	dec	$04			; |
 	bne	-			;/
-else
-	iny
-endif
 .return
-	rtl
+	ply
+endif
+
+	dey
+	ldx	$02
+	jml	$02a846|!bankB
 
 ;--- Subroutine for read extra bytes
 if !true == !EXTRA_BYTES_EXT

--- a/asm/giepy/shooter.asm
+++ b/asm/giepy/shooter.asm
@@ -7,16 +7,21 @@ pushpc
 		jsl	SetShooterExBits
 		nop
 
-if !true == !EXTRA_BYTES_EXT
-	if !sa1	
+	%org_assert_word($02a8d8, 7820)
+		jmp	$ab78
+
+	if !true == !sa1
 		%org_assert_long2($02abeb, 5c02,a6c8)
 	else
 		%org_assert_long2($02abeb, e802,a6c8)
 	endif
-			jsl	LoadShooterExByte
-endif
+	jml	LoadShooterExByte
 
-	%org_assert_long2($02b39e, abde,0390)
+	if !true == !sa1
+		%org_assert_long2($02b395, f077,abbc)
+	else
+		%org_assert_long2($02b395, f017,abbc)
+	endif
 		jml	ShooterHijack
 pullpc
 
@@ -40,9 +45,11 @@ endif
 ;-------------------------------------------------
 ; Load Shooter's Extra byte
 ;-------------------------------------------------
-if !true == !EXTRA_BYTES_EXT
+
 LoadShooterExByte:
 	%putdebug("LoadShooterExByte")
+if !true == !EXTRA_BYTES_EXT
+	phy
 	jsr	LoadExBytesSub
 	beq	+			;\  Load extra bytes.
 -	lda.b	[$ce],y			; | if extra bytes size greater than 4,
@@ -50,16 +57,22 @@ LoadShooterExByte:
 	iny				; | latest extra byte value.
 	dec	$04			; |
 	bne	-			;/
-+	ldx.b	$02
-	inx
-	rtl
++	ply
 endif
+	dey
+	ldx.b	$02
+	jml	$02a846|!bankB
 
 ;-------------------------------------------------
 ; Shooter Hijack
 ;-------------------------------------------------
 ShooterHijack:
 	%putdebug("ShooterHijack")
+	pha
+	ldy	!17ab,x
+	beq	+
+	lda	$13
+	lsr
 	bcc	+
 	dec	!17ab,x
 +	lda.l	!extra_bits_sh,x	; C---EE-- : C=custom, EE=sprite grp

--- a/src/mewthree/Exbytes.c
+++ b/src/mewthree/Exbytes.c
@@ -8,7 +8,7 @@
 #include "mewthree/Rats.h"
 #include "mewthree/Exbytes.h"
 
-#define SPRDATA_MAX	0x200		/** Usually within 0x100 bytes... */
+#define SPRDATA_MAX	15*255+1	/** 255 sprites with 12 extra bytes each */
 #define SprAddrPtr	0x02ec00	/** snes:$05:ec00, 2bytes * 512 */
 #define SprBankPtr	0x077100	/** snes:$0e:f100, 1byte  * 512 */
 

--- a/src/mewthree/Uninstall.c
+++ b/src/mewthree/Uninstall.c
@@ -132,7 +132,11 @@ static bool Restore_v0100(RomFile* rom, Observers* obs)
 		/* load.asm */
 		{ 0x02a837, 4, (uint8*)"\x29\x10\x85\x02"     },
 		{ 0x02a861, 4, (uint8*)"\xb7\xce\x85\x05"     },
+		{ 0x028b1d, 3, (uint8*)"\x20\xfc\xa7"         },
+		{ 0x02ac7a, 6, (uint8*)"\x20\x02\xa8\x20\x02\xa8" },
+		{ 0x02acba, 6, (uint8*)"\x20\x02\xa8\x20\x02\xa8" },
 		{ 0x02a846, 4, (uint8*)"\xc8\xc8\xe8\x80"     },
+		{ 0x02b5ec, 24, (uint8*)"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" },
 
 		/* normspr.asm */
 		{ 0x02a971, 4, (uint8*)"\xc8\xc8\xa5\x04"     },
@@ -148,6 +152,7 @@ static bool Restore_v0100(RomFile* rom, Observers* obs)
 
 		/* shooter.asm */
 		{ 0x02b39e, 4, (uint8*)"\x90\x03\xde\xab"     },
+		{ 0x02a8d8, 3, (uint8*)"\x20\x78\xab"         },
 
 		/* generator.asm */
 		{ 0x02a8b4, 4, (uint8*)"\x38\xe9\xcb\x1a"     },
@@ -178,6 +183,9 @@ static bool Restore_v0100(RomFile* rom, Observers* obs)
 	/* Restore data (LoROM)				*/
 	/************************************************/
 	static RestoreData LoRomRestore[] = {
+		/* init.asm */
+		{ 0x02abf2, 2, (uint8*)"\xa2\x3f"             },
+
 		/* normspr.asm */
 		{ 0x02a9a3, 4, (uint8*)"\xda\xb5\x9e\xaa"     },
 		{ 0x02a9d4, 4, (uint8*)"\x9d\xe2\x1f\xc8"     },
@@ -190,6 +198,7 @@ static bool Restore_v0100(RomFile* rom, Observers* obs)
 		/* shooter.asm */
 		{ 0x02aba3, 5, (uint8*)"\xe9\xc8\x9d\x83\x17" },
 		{ 0x02abeb, 4, (uint8*)"\xc8\xa6\x02\xe8"     },
+		{ 0x02b395, 4, (uint8*)"\xbc\xab\x17\xf0"     },
 
 		/* scroll.asm */
 		{ 0x05bc79, 4, (uint8*)"\xad\x9d\x00\xd0"     },
@@ -229,6 +238,7 @@ static bool Restore_v0100(RomFile* rom, Observers* obs)
 		/* shooter.asm */
 		{ 0x02aba3, 5, (uint8*)"\xe9\xc8\x9d\x83\x77" },
 		{ 0x02abeb, 4, (uint8*)"\xc8\xa6\x02\x5c"     },
+		{ 0x02b395, 4, (uint8*)"\xbc\xab\x77\xf0"     },
 
 		/* scroll.asm */
 		{ 0x05bc79, 4, (uint8*)"\xad\x9d\x30\xd0"     },


### PR DESCRIPTION
# Summary
This pull request makes some changes to the sprite loading routine. It fixes several issues (including some not reported). More importantly, it removes the hard limit of the loading routine by adjusting the pointer to the sprite data when it is close to overflowing. This allows you to put 128 sprites in a level (or 255 with SA-1), the largest size $7E1938 can handle. Previously, both LoROM and SA-1 could load up to 84, even less with extra bytes.

There are two very important things to consider with this.

1. I don't know C, so it is currently impossible to uninstall this or upgrade from an earlier GIEPY version. `Uninstall.c` will have to be adjusted with the new hijacks.
2. With this pull request's new features, the sprite data of a level can grow as large as 3826 bytes (this is the equivalent of 255 sprites with 12 extra bytes each). `Exbytes.c` will fail with such large sprite data because of hardcoded limit of 512 bytes (`SPRDATA_MAX`).

[These are all sprites and ROMs I used for testing this pull request.](https://github.com/boldowa/GIEPY/files/2153177/resources.zip)